### PR TITLE
Fix NoSuchMethodError when tap on share button

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -13,7 +13,6 @@ import 'package:xkcd/widgets/comic_view.dart';
 
 class HomePage extends StatelessWidget {
   static final String pageRoute = '/home-page';
-  final ComicModel model = ComicModel();
   final SharedPreferences prefs = Preferences.prefs;
 
   @override
@@ -65,7 +64,7 @@ class HomePage extends StatelessWidget {
         IconButton(
           icon: Icon(OMIcons.share, color: themeData.primaryColor),
           onPressed: () {
-            model.shareComic();
+            ScopedModel.of<ComicModel>(context).shareComic();
           },
         ),
       ],


### PR DESCRIPTION
```
══╡ EXCEPTION CAUGHT BY GESTURE ╞════════════════════════════════════════════════════════
The following NoSuchMethodError was thrown while handling a gesture:
The getter 'num' was called on null.
Receiver: null
Tried calling: num

When the exception was thrown, this was the stack:
#0   Object.noSuchMethod (dart:core/runtime/libobject_patch.dart:50:5)
#1   ComicModel.shareComic (package:xkcd/models/comic_model.dart:62:52)
#2   HomePage._buildAppBar.<anonymous closure> (package:xkcd/pages/home_page.dart:68:19)
```

Using ` ScopedModel.of` instead of creating second instance of model class